### PR TITLE
event作成のAPI stabを作る(post編)

### DIFF
--- a/savoten/app.py
+++ b/savoten/app.py
@@ -52,7 +52,7 @@ def create_event():
     
     events[event_id] = event
 
-    return make_response(f"create event{event.__dict__}!", 200)
+    return make_response(f"create event{event.__dict__}!", 201)
 
 @api.errorhandler(404)
 def not_found(error):

--- a/savoten/app.py
+++ b/savoten/app.py
@@ -54,7 +54,7 @@ def create_event():
 
     events[event_id] = event
 
-    return make_response(f"create event{event.__dict__}!", 201)
+    return make_response(f"create event{vars(event)})!", 201)
 
 
 @api.errorhandler(404)

--- a/savoten/app.py
+++ b/savoten/app.py
@@ -6,6 +6,7 @@ api = Flask(__name__)
 
 events = {}
 
+
 @api.route('/events/<string:event_id>', methods=['GET'])
 def get_event(event_id):
     try:
@@ -22,24 +23,25 @@ def get_event(event_id):
         abort(404)
 
     result = {
-        "result":True,
-        "data":{
-            "event_id":event.id,
-            "event_items":event.items,
-            "period_start":event.period.start,
+        "result": True,
+        "data": {
+            "event_id": event.id,
+            "event_items": event.items,
+            "period_start": event.period.start,
             "period_end": event.period.end,
-            "description":event.description
-            }
+            "description": event.description
         }
+    }
 
     return make_response(jsonify(result))
 
+
 @api.route('/events', methods=['POST'])
 def create_event():
-    
+
     print(events)
     event_id = len(events) + 1
-    start = datetime.datetime.now() 
+    start = datetime.datetime.now()
     end = start + datetime.timedelta(hours=24)
 
     args = {
@@ -49,14 +51,16 @@ def create_event():
         'description': 'description for test'
     }
     event = domain.Event(**args)
-    
+
     events[event_id] = event
 
     return make_response(f"create event{event.__dict__}!", 201)
 
+
 @api.errorhandler(404)
 def not_found(error):
     return make_response(jsonify({'error': 'Not found'}), 404)
+
 
 if __name__ == '__main__':
     api.run(host='0.0.0.0', port=8000)

--- a/savoten/app.py
+++ b/savoten/app.py
@@ -4,6 +4,8 @@ from savoten import domain
 
 api = Flask(__name__)
 
+events = {}
+
 @api.route('/events/<string:event_id>', methods=['GET'])
 def get_event(event_id):
     try:
@@ -31,6 +33,26 @@ def get_event(event_id):
         }
 
     return make_response(jsonify(result))
+
+@api.route('/events', methods=['POST'])
+def create_event():
+    
+    print(events)
+    event_id = len(events) + 1
+    start = datetime.datetime.now() 
+    end = start + datetime.timedelta(hours=24)
+
+    args = {
+        'name': event_id,
+        'items': [],
+        'period': domain.Period(start, end),
+        'description': 'description for test'
+    }
+    event = domain.Event(**args)
+    
+    events[event_id] = event
+
+    return make_response(f"create event{event.__dict__}!", 200)
 
 @api.errorhandler(404)
 def not_found(error):

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -26,6 +26,7 @@ def test_get_event(get_event_test_case):
     response = test_app.get(uri)
     assert response.status_code == expect
 
+
 @pytest.fixture(
     scope='function',
     params=[
@@ -39,13 +40,13 @@ def test_get_event(get_event_test_case):
         }
     ]
 )
-
 def post_event_test_case(request):
     return request.param
 
+
 def test_post_event(post_event_test_case):
     uri = post_event_test_case['uri']
-    expect = post_event_test_case['expect'] 
+    expect = post_event_test_case['expect']
     test_app = app.api.test_client()
-    response = test_app.post(uri) 
+    response = test_app.post(uri)
     assert response.status_code == expect

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -31,7 +31,7 @@ def test_get_event(get_event_test_case):
     params=[
         {
             'uri': '/events',
-            'expect': 200
+            'expect': 201
         },
         {
             'uri': '/events/hogehoge',

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -25,3 +25,27 @@ def test_get_event(get_event_test_case):
     test_app = app.api.test_client()
     response = test_app.get(uri)
     assert response.status_code == expect
+
+@pytest.fixture(
+    scope='function',
+    params=[
+        {
+            'uri': '/events',
+            'expect': 200
+        },
+        {
+            'uri': '/events/hogehoge',
+            'expect': 405
+        }
+    ]
+)
+
+def post_event_test_case(request):
+    return request.param
+
+def test_post_event(post_event_test_case):
+    uri = post_event_test_case['uri']
+    expect = post_event_test_case['expect'] 
+    test_app = app.api.test_client()
+    response = test_app.post(uri) 
+    assert response.status_code == expect


### PR DESCRIPTION
* closes #9
* [x] PYTHONPATH=./ scripts/run_tests が成功する

# 目的
* event作成のAPI stabにイベント新規作成の機能を追加する

# 仕様
* /eventsにPOSTがあったら新規イベントを作成
* stabなので仮の仕様として、グローバル変数でeventsというdictを持たせnameにユニークな番号をkeyにeventオブジェクトを追加していく
    * 他のフィールドはアテの値を入れている
* イベント作成に成功したらステータスコード201、それ以外のuriにpostされたら405が返される