### PR TITLE
Remake get_event stub

### DIFF
--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -3,29 +3,32 @@ import pytest
 from savoten import app
 
 
-@pytest.fixture(
-    scope='function',
-    params=[
-        {
-            'uri': '/events/1234',
-            'expect': 200
-        },
-        {
-            'uri': '/events/',
-            'expect': 404
-        }
-    ]
-)
-def get_event_test_case(request):
-    return request.param
-
-
-def test_get_event(get_event_test_case):
-    uri = get_event_test_case['uri']
-    expect = get_event_test_case['expect']
+@pytest.fixture(scope='class')
+def test_app():
+    uri = '/events'
+    post_params = {
+        "name": "test_name",
+        "start": "2019-08-01 01:02:03.123456",
+        "end": "2020-08-01 01:02:03.123456",
+        "description": "test_desc"
+    }
     test_app = app.api.test_client()
-    response = test_app.get(uri)
-    assert response.status_code == expect
+    response = test_app.post(uri, data=json.dumps(
+        post_params), content_type='application/json')
+    if response.status_code != 201:
+        assert False
+    return test_app
+
+
+@pytest.mark.parametrize('uri, expect_status_code, expect_result', [
+    ('/events/1', 200, True),
+    ('/events/999', 200, False)
+])
+class TestGetEventClass():
+    def test_get_event(self, test_app, uri, expect_status_code, expect_result):
+        response = test_app.get(uri)
+        assert (response.status_code == expect_status_code
+                and response.json['result'] is expect_result)
 
 
 @pytest.fixture(
@@ -63,5 +66,6 @@ def test_post_event(post_event_test_case):
     expect = post_event_test_case['expect']
     post_params = post_event_test_case['post_params']
     test_app = app.api.test_client()
-    response = test_app.post(uri, data=json.dumps(post_params), content_type='application/json')
+    response = test_app.post(uri, data=json.dumps(
+        post_params), content_type='application/json')
     assert response.status_code == expect


### PR DESCRIPTION
# 概要

- get_eventの処理がstubとして十分でなかったので作り直した。
  - 修正前：リクエストパスからevent_idを抽出し、そのIDでイベントを作って見つかったように返す
  - 修正後：リクエストパスからevent_idを抽出し、モックDB（events）を探して応答
- 合わせてtestも修正