### PR TITLE
delete abc package from pipfile because abc is default package.

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,7 +7,6 @@ name = "pypi"
 filelock = "*"
 flask = "*"
 python-dateutil = "*"
-abc = "*"
 
 [dev-packages]
 isort = "*"


### PR DESCRIPTION
abc が pipenv install 不要なため削除しました。