### PR TITLE
Feature/add event page

### DIFF
--- a/savoten/handler/event_view.py
+++ b/savoten/handler/event_view.py
@@ -5,6 +5,10 @@ event_view = Blueprint('event_view',
                        template_folder='templates',
                        static_folder='static')
 
+@event_view.route('/events/<int:id>', methods=['GET'])
+def get_event_page(id):
+    return render_template('event.html')
+
 
 @event_view.route('/events', methods=['GET'])
 def get_events_page():

--- a/savoten/static/js/event.js
+++ b/savoten/static/js/event.js
@@ -1,0 +1,70 @@
+const eventKeyToDisplayNameMap = {
+  "id": "ID",
+  "name": "イベント名",
+  "items": "項目",
+  "start": "開始時刻",
+  "end": "終了時刻",
+  "description": "備考",
+  "anonymous": "匿名投票",
+  "created_at": "作成日時",
+  "updated_at": "更新日時",
+  "deleted_at": "削除日時"
+}
+
+const displayEventInfomationTable = () => {
+  // アクセスURL/evests/${id}から${id}を取得
+  const path = location.pathname;
+  const event_id = path.split('/').pop();
+  $.getJSON({
+    url: `/api/v1/events/${event_id}`
+  }).then(
+    (data, status, xhr) => {
+      const event = data["data"];
+      if (!Object.keys(event).length) {
+        alert(`Event(id: ${id}) does not exist.`);
+        return;
+      }
+      const dataKeys = ["id", "name", "items", "start", "end", "description", "anonymous", "created_at", "updated_at", "deleted_at"];
+      const tableId = "eventInfomationTable";
+      makeTable(event, dataKeys, tableId);
+    },
+    (xhr, textStatus, errorThrown) => {
+      showRequestError(xhr, textStatus, errorThrown);
+    }
+  );
+};
+
+const makeTable = (data, dataKeys, tableId) => {
+  const table = document.getElementById(tableId);
+  for (let key of dataKeys) {
+    const row = table.insertRow(-1);
+    let cell = row.insertCell(-1);
+    cell.appendChild(document.createTextNode(eventKeyToDisplayNameMap[key]));
+    cell = row.insertCell(-1);
+    if (data[key] == null){
+      cell.appendChild(document.createTextNode("No Data"));
+    } else {
+    cell.appendChild(document.createTextNode(data[key]));
+    }
+  }
+};
+
+const showRequestError = (xhr, textStatus, errorThrown) => {
+  try {
+    const responseData = $.parseJSON(xhr.responseText);
+    console.log(responseData);
+  } catch (e) {
+    console.log(e);
+  }
+  if (Number(xhr.status) < 500) {
+    alert(
+      `${xhr.status} ${errorThrown} : Invalid Request. Please check input value.`
+    );
+  } else {
+    alert(
+      `${xhr.status} ${errorThrown} : Internal server error. Please contact server administrator.`
+    );
+  }
+};
+
+window.addEventListener("load", displayEventInfomationTable);

--- a/savoten/static/js/get_events.js
+++ b/savoten/static/js/get_events.js
@@ -24,6 +24,11 @@ const makeTable = (data, dataKeys, tableId) => {
   // set table_head
   const thead = table.createTHead();
   const thRow = thead.insertRow(0);
+
+  // イベント詳細ボタン列の追加処理
+  const cell = thRow.insertCell();
+  cell.textContent = "イベント詳細";
+
   for (let i = 0; i < dataKeys.length; i++) {
     const cell = thRow.insertCell();
     cell.textContent = dataKeys[i];
@@ -31,12 +36,22 @@ const makeTable = (data, dataKeys, tableId) => {
   // set table_body
   for (let i = 0; i < data.length; i++) {
     const bodyRow = table.insertRow(-1);
+
+    // イベント詳細遷移のボタン追加処理
+    const cell = bodyRow.insertCell(-1);
+    const button = document.createElement("button");
+    button.type = "button";
+    button.textContent = "詳細";
+    button.classList.add("btn", "btn-sm", "btn-primary");
+    button.onclick = () => {
+      document.location = `${location.origin}/events/${data[i]["id"]}`;
+      return
+    }
+    cell.appendChild(button);
+
     for (let j = 0; j < dataKeys.length; j++) {
       const cell = bodyRow.insertCell(-1);
-      const anchor = document.createElement("a");
-      anchor.href = `${location.origin}/event/${data[i]["id"]}`;
-      anchor.textContent = data[i][dataKeys[j]];
-      cell.appendChild(anchor);
+      cell.appendChild(document.createTextNode(data[i][dataKeys[j]]));
     }
   }
 };

--- a/savoten/static/js/get_events.js
+++ b/savoten/static/js/get_events.js
@@ -33,7 +33,10 @@ const makeTable = (data, dataKeys, tableId) => {
     const bodyRow = table.insertRow(-1);
     for (let j = 0; j < dataKeys.length; j++) {
       const cell = bodyRow.insertCell(-1);
-      cell.appendChild(document.createTextNode(data[i][dataKeys[j]]));
+      const anchor = document.createElement("a");
+      anchor.href = `${location.origin}/event/${data[i]["id"]}`;
+      anchor.textContent = data[i][dataKeys[j]];
+      cell.appendChild(anchor);
     }
   }
 };

--- a/savoten/templates/event.html
+++ b/savoten/templates/event.html
@@ -23,7 +23,7 @@
   <div class="container">
     <div class="card card-default">
       <div class="card-heading">
-        <h1>Get Events</h1>
+        <h1>Event Info</h1>
         <div class="card-body">
           <div class="form-group">
             <table class="table" id ="eventInfomationTable"></table>

--- a/savoten/templates/event.html
+++ b/savoten/templates/event.html
@@ -23,7 +23,7 @@
   <div class="container">
     <div class="card card-default">
       <div class="card-heading">
-        <h1>Event Info</h1>
+        <h1>Event Infomation</h1>
         <div class="card-body">
           <div class="form-group">
             <table class="table" id ="eventInfomationTable"></table>

--- a/savoten/templates/event.html
+++ b/savoten/templates/event.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Event Infomation</title>
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
+    integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T"
+    crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.4.1.min.js"
+    integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo="
+    crossorigin="anonymous"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js"
+    integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1"
+    crossorigin="anonymous"></script>
+  <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"
+    integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM"
+    crossorigin="anonymous"></script>
+</head>
+
+<body>
+  <div class="container">
+    <div class="card card-default">
+      <div class="card-heading">
+        <h1>Get Events</h1>
+        <div class="card-body">
+          <div class="form-group">
+            <table class="table" id ="eventInfomationTable"></table>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <script src="/static/js/event.js"></script>
+</body>
+
+</html>


### PR DESCRIPTION
# 概要

- event単体の情報を表示するページを作った
  - `/events/${id}`
- 合わせて/eventsのテーブルに、eventページへ遷移するボタンを追加した

# 確認

- (app.pyを起動して、イベント作成ページからイベントを2個作成しておく)
- [x] /eventsページでid=1のイベントの1列目の詳細ボタンを押して/event/1ページに遷移する
- [x] /eventsページでid=2のイベントの1列目の詳細ボタンを押して/event/2ページに遷移する
  - (ボタンのリンク先がidによって正しく生成されている)

# 備考(この先の機能追加のイメージ)

- event_itemの追加を/eventのページに今後追加する予定です
  - /eventの「項目」の行に「イベント追加」のボタンをつけて、イベント作成ページへ遷移、、、みたいな
  - event_item周りがまだないので、そこが一式整ったら改修します