### PR TITLE
Fix/add event_id to event_item properties

### DIFF
--- a/savoten/domain/event_item.py
+++ b/savoten/domain/event_item.py
@@ -10,7 +10,8 @@ class EventItem:
                  seats=1,
                  max_choice=1,
                  min_choice=1,
-                 id=None):
+                 id=None,
+                 event_id=None):
         self.id = id
         self.name = name
         self.candidates = candidates
@@ -18,6 +19,7 @@ class EventItem:
         self.seats = seats
         self.max_choice = max_choice
         self.min_choice = min_choice
+        self.event_id = event_id
 
     @property
     def candidates(self):

--- a/tests/unit/domain/test_event_item.py
+++ b/tests/unit/domain/test_event_item.py
@@ -17,7 +17,8 @@ class TestInit:
                                  'seats': 2,
                                  'max_choice': 3,
                                  'min_choice': 4,
-                                 'id': 5
+                                 'id': 5,
+                                 'event_id': 1
                              }, {
                                  'name': 'name',
                                  'candidates': [candidate],
@@ -25,7 +26,8 @@ class TestInit:
                                  'seats': 2,
                                  'max_choice': 3,
                                  'min_choice': 4,
-                                 'id': 5
+                                 'id': 5,
+                                 'event_id': 1
                              }),
                               ({
                                   'name': 'name',
@@ -37,7 +39,8 @@ class TestInit:
                                   'seats': 1,
                                   'max_choice': 1,
                                   'min_choice': 1,
-                                  'id': None
+                                  'id': None,
+                                  'event_id': None
                               })])
     def test_succeeds_initialization_with_valid_args(self, valid_args,
                                                      expected):


### PR DESCRIPTION
# 概要

- event_itemのpropertyにevent_idがなかったので追加しました。
  - event_itemは自分が関係するeventのidを保持する設計だったと思ってます
    - 親:event(id=1)に子:event_item1(event_id=1), event_item2(event_id=1)...が紐づく形
  - (参考)https://github.com/sato-mh/savoten/wiki のevent_item

- event_itemのpropertyの追加とtestをちょこっと修正してあります。

# 確認

- [ ] `pipenv run test` が通る