### PR TITLE
Feature/add circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,22 +1,20 @@
 version: 2
 jobs:
   build:
-    machine: true
+    docker:
+      - image: python:3.7.4-stretch
+    environment:
+      PYTHONPATH: /root/savoten
+      TZ: /usr/share/zoneinfo/Asia/Tokyo
+    working_directory: /root/savoten
     steps:
       - checkout
       - run:
-          name: Create .env
+          name: Install pipenv
           command: |
-            cat << EOF >> .env
-            UID=$(id -u)
-            GID=$(id -g)
-            EOF
+              pip install --upgrade pip && \
+              pip install pipenv
+              pipenv install -d --skip-lock
       - run:
-          name: Build Docker Image
-          command: docker-compose build
-      - run:
-          name: Docker-compose Up
-          command: docker-compose up -d
-      - run:
-          name: Run tests
-          command: docker-compose exec app pipenv run scripts/run_tests
+          name: Run test
+          command: pipenv run scripts/run_tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
       - run:
           name: Install pipenv
           command: |
-              pip install --upgrade pip && \
+              pip install --upgrade pip
               pip install pipenv
               pipenv install -d --skip-lock
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,22 @@
+version: 2
+jobs:
+  build:
+    machine: true
+    steps:
+      - checkout
+      - run:
+          name: Create .env
+          command: |
+            cat << EOF >> .env
+            UID=$(id -u)
+            GID=$(id -g)
+            EOF
+      - run:
+          name: Build Docker Image
+          command: docker-compose build
+      - run:
+          name: Docker-compose Up
+          command: docker-compose up -d
+      - run:
+          name: Run tests
+          command: docker-compose exec app pipenv run scripts/run_tests

--- a/savoten/handler/event_view.py
+++ b/savoten/handler/event_view.py
@@ -5,6 +5,7 @@ event_view = Blueprint('event_view',
                        template_folder='templates',
                        static_folder='static')
 
+
 @event_view.route('/events/<int:id>', methods=['GET'])
 def get_event_page(id):
     return render_template('event.html')


### PR DESCRIPTION
# 概要

- CIを導入してみました
- ~docker-compose.yamlをそのままCircleCIで使って楽したかったのでそういう設定(VM実行&Docker-compose)にしてみました。~
  - CircleCIコンテナを使うように修正しました。
    - 普段はon_memoryでDBコンテナを代替するので1コンテナ実行でOK
    - CircleCIコンテナ実行の方が1分くらい早い

# 設定お願い

- [x] リポジトリのOwnerのGithubアカウントでCircleCIにログインし、このプロジェクトをCircleCIでフォロー
- [ ] CircleCIで初回ビルドがうまくいくことを確認する
- [x] CircleCIの本プロジェクトのbuildのURLをslackで共有
  - [メンバーの追加は直リンク共有すればいいらしいです](https://support.circleci.com/hc/ja/articles/360000026907-%E3%83%81%E3%83%BC%E3%83%A0%E3%83%A1%E3%83%B3%E3%83%90%E3%83%BC%E3%82%92%E7%B5%84%E7%B9%94%E3%81%AB%E6%8B%9B%E5%BE%85%E3%81%A7%E3%81%8D%E3%81%AA%E3%81%84)
- slack通知設定とかはプロジェクト入れるようになったら私やります