### PR TITLE
add jsonify encoder

### DIFF
--- a/savoten/handler/util.py
+++ b/savoten/handler/util.py
@@ -19,5 +19,19 @@ class DomainEncoder(json.JSONEncoder):
         # 自作classのメンバにさらに自作classが入れ子になっていることがあるが
         # 子のclassについても再起的に呼ばれ、すべてjsonになって戻ってくる
         if isinstance(obj, self._domain_class_tuple):
-            return vars(obj)
+            new_obj = copy.deepcopy(obj)
+            return self._encode_obj_to_dict(new_obj)
         return super(DomainEncoder, self).default(obj)
+
+    def _encode_obj_to_dict(self, obj):
+        obj_dict = vars(obj)
+        return self._strip_key_head_underbar(obj_dict)
+
+    # 変数名の頭にアンダーバーがあれば一律で外す
+    # private変数で定義されている変数の頭のアンダーバーを外す意図
+    def _strip_key_head_underbar(self, obj_dict):
+        for key in obj_dict:
+            if key.startswith('_'):
+                stripped_key = key.lstrip('_')
+                obj_dict[stripped_key] = obj_dict.pop(key)
+        return obj_dict

--- a/savoten/handler/util.py
+++ b/savoten/handler/util.py
@@ -1,0 +1,23 @@
+import copy
+import json
+from datetime import datetime
+
+from savoten.domain import Candidate, Event, EventItem, Period, User
+
+
+# Domainの自作classをjsonエンコードする際の処理
+# json.dumpsやjsonifyで使用
+class DomainEncoder(json.JSONEncoder):
+    _domain_class_tuple = (Event, EventItem, User, Candidate, Period)
+
+    def default(self, obj):
+        # Datetime型についてもjson化の際の定義が必要なのでその記述
+        # PeriodクラスのメンバにDatetime型がいる
+        if isinstance(obj, datetime):
+            return obj.isoformat()
+        # Domainで定義する自作classのjsonエンコード定義
+        # 自作classのメンバにさらに自作classが入れ子になっていることがあるが
+        # 子のclassについても再起的に呼ばれ、すべてjsonになって戻ってくる
+        if isinstance(obj, self._domain_class_tuple):
+            return vars(obj)
+        return super(DomainEncoder, self).default(obj)

--- a/tests/unit/handler/test_util.py
+++ b/tests/unit/handler/test_util.py
@@ -60,7 +60,11 @@ event_args = {
     'name': 'event_name',
     'items': [event_item],
     'period': period,
-    'description': 'event_description'
+    'description': 'event_description',
+    'anonymous': False,
+    'created_at': None,
+    'updated_at': None,
+    'deleted_at': None
 }
 event = Event(**event_args)
 expected_event_dict = {
@@ -68,7 +72,11 @@ expected_event_dict = {
     'name': 'event_name',
     'items': [expected_event_item_dict],
     'period': isoformatted_period,
-    'description': 'event_description'
+    'description': 'event_description',
+    'anonymous': False,
+    'created_at': None,
+    'updated_at': None,
+    'deleted_at': None
 }
 
 domains_objects = {
@@ -90,5 +98,4 @@ def test_succeeds_when_jsonify_domains(domain_object, expected):
         response = jsonify(domain_object)
     # json化したデータが正しいかの判定のためにjson.loadsしてdictに格納し直す
     parsed_response = json.loads(response.data)
-    for key in expected:
-        assert parsed_response[key] == expected[key]
+    assert parsed_response == expected

--- a/tests/unit/handler/test_util.py
+++ b/tests/unit/handler/test_util.py
@@ -28,7 +28,7 @@ candidate_args = {'id': 1, 'user': user, 'description': 'candidate_description'}
 candidate = Candidate(**candidate_args)
 expected_candidate_dict = {
     'id': 1,
-    '_user': expected_user_dict,
+    'user': expected_user_dict,
     'description': 'candidate_description'
 }
 
@@ -36,7 +36,7 @@ start = datetime.datetime.now()
 end = start + datetime.timedelta(hours=1)
 period_args = {'start': start, 'end': end}
 period = Period(**period_args)
-isoformatted_period = {'_start': start.isoformat(), '_end': end.isoformat()}
+isoformatted_period = {'start': start.isoformat(), 'end': end.isoformat()}
 
 event_item_args = {
     'id': 1,
@@ -48,7 +48,7 @@ event_item = EventItem(**event_item_args)
 expected_event_item_dict = {
     'id': 1,
     'name': 'event_item_name',
-    '_candidates': [expected_candidate_dict],
+    'candidates': [expected_candidate_dict],
     'seats': 1,
     'max_choice': 1,
     'min_choice': 1,
@@ -66,8 +66,8 @@ event = Event(**event_args)
 expected_event_dict = {
     'id': 1,
     'name': 'event_name',
-    '_items': [expected_event_item_dict],
-    '_period': isoformatted_period,
+    'items': [expected_event_item_dict],
+    'period': isoformatted_period,
     'description': 'event_description'
 }
 

--- a/tests/unit/handler/test_util.py
+++ b/tests/unit/handler/test_util.py
@@ -1,0 +1,94 @@
+import datetime
+import json
+
+import pytest
+from flask import Flask, jsonify
+
+from savoten.domain import Candidate, Event, EventItem, Period, User
+from savoten.handler.util import DomainEncoder
+from tests.util import get_public_vars
+
+app = Flask(__name__)
+# jsonifyで日本語処理を受け付ける設定
+app.config['JSON_AS_ASCII'] = False
+
+# jsonifyでdomainのclassを含むエンコードを行う設定
+app.json_encoder = DomainEncoder
+
+user_args = {
+    'id': 1,
+    'name': 'user_name',
+    'email': 'user_email@example.com',
+    'permission': 100
+}
+user = User(**user_args)
+expected_user_dict = vars(user)
+
+candidate_args = {'id': 1, 'user': user, 'description': 'candidate_description'}
+candidate = Candidate(**candidate_args)
+expected_candidate_dict = {
+    'id': 1,
+    '_user': expected_user_dict,
+    'description': 'candidate_description'
+}
+
+start = datetime.datetime.now()
+end = start + datetime.timedelta(hours=1)
+period_args = {'start': start, 'end': end}
+period = Period(**period_args)
+isoformatted_period = {'_start': start.isoformat(), '_end': end.isoformat()}
+
+event_item_args = {
+    'id': 1,
+    'name': 'event_item_name',
+    'candidates': [candidate],
+    'description': 'event_item_description'
+}
+event_item = EventItem(**event_item_args)
+expected_event_item_dict = {
+    'id': 1,
+    'name': 'event_item_name',
+    '_candidates': [expected_candidate_dict],
+    'seats': 1,
+    'max_choice': 1,
+    'min_choice': 1,
+    'description': 'event_item_description'
+}
+
+event_args = {
+    'id': 1,
+    'name': 'event_name',
+    'items': [event_item],
+    'period': period,
+    'description': 'event_description'
+}
+event = Event(**event_args)
+expected_event_dict = {
+    'id': 1,
+    'name': 'event_name',
+    '_items': [expected_event_item_dict],
+    '_period': isoformatted_period,
+    'description': 'event_description'
+}
+
+domains_objects = {
+    'period': (period, isoformatted_period),
+    'user': (user, expected_user_dict),
+    'candidate': (candidate, expected_candidate_dict),
+    'event_item': (event_item, expected_event_item_dict),
+    'event': (event, expected_event_dict)
+}
+
+
+@pytest.mark.parametrize('domain_object, expected',
+                         list(domains_objects.values()),
+                         ids=list(domains_objects.keys()))
+# jsonifyでdomainのオブジェクトをjson化するテスト
+# savoten.handler.util.DomainEncoderクラスを予めjsonifyで使用する設定をして実行
+def test_succeeds_when_jsonify_domains(domain_object, expected):
+    with app.app_context():
+        response = jsonify(domain_object)
+    # json化したデータが正しいかの判定のためにjson.loadsしてdictに格納し直す
+    parsed_response = json.loads(response.data)
+    for key in expected:
+        assert parsed_response[key] == expected[key]


### PR DESCRIPTION
# 概要

- domainのオブジェクトをjson変換するための処理を追加しました
  - 例えばAPI層(handler)でgetリクエストのresponse返すときに使用することを想定してます
  - echoのjsonifyを利用して、json変換するときの処理を書いたclassを渡す形で実装してます

# チェックして欲しい(気になってる)ところ

- [ ] [test](https://app.circleci.com/jobs/github/sato-mh/savoten/44)がOK
- [ ] json化後の出力仕様に違和感ないか
  - response時にprivate変数のkey名の頭の_を全部外す処理にしています。
  - 例： `{_items: [] }` → `{`{items`: []}`
  - response読む側で_あるなしを気にしなくていいようにしたいのでこの仕様にしてます
  - 本当にkey名に頭に_をつけたままレスポンスしたいケースがあると困るけど、、、ないですよね
  - こっちの方が使いやすいとかあれば修正案ください
- [ ] ファイル構成に違和感ないか
  - json化の処理を置く場所、handlerでしか使わない想定なのでhandler.utilに書くでいいでしょうか
- [ ] テストの形式、書き方に改善可能な点がないか(思いつけば)
  - domainオブジェクトをjson化した後にもう一度dictにパースしなおして、結果比較用のdictと比較する形式でtestしてます
    - 比較用のデータをstringで全部手打ちする手間を省くため
  - 結果比較用のdictをtestファイルで一個ずつ準備してるが、もう少しスマートにできそうな気が...
    - テストデータ準備が面倒なのは避けられないのだろうか...